### PR TITLE
Make paintbrush color blocks in straight line

### DIFF
--- a/src/main/java/buildcraft/BuildCraftCore.java
+++ b/src/main/java/buildcraft/BuildCraftCore.java
@@ -203,6 +203,7 @@ public class BuildCraftCore extends BuildCraftMod {
     public static boolean canEnginesExplode = false;
     public static boolean useServerDataOnClient = true;
     public static boolean alphaPassBugPresent = true;
+    public static int maxPaintedBlocks = -1;
     public static int itemLifespan = 1200;
     public static int updateFactor = 10;
     public static int builderMaxPerItemFactor = 1024;
@@ -401,6 +402,12 @@ public class BuildCraftCore extends BuildCraftMod {
                 "worldgen.generateWaterSprings",
                 true,
                 "Should BuildCraft generate water springs?",
+                ConfigManager.RestartRequirement.GAME);
+
+        mainConfigManager.register(
+                "general.maxPaintedBlocks",
+                -1,
+                "How many blocks can paintbrush paint at max(-1) for unlimited",
                 ConfigManager.RestartRequirement.GAME);
 
         reloadConfig(ConfigManager.RestartRequirement.GAME);
@@ -779,6 +786,7 @@ public class BuildCraftCore extends BuildCraftMod {
             hidePowerNumbers = mainConfigManager.get("display.hidePowerValues").getBoolean();
             itemLifespan = mainConfigManager.get("general.itemLifespan").getInt();
             canEnginesExplode = mainConfigManager.get("general.canEnginesExplode").getBoolean();
+            maxPaintedBlocks = mainConfigManager.get("general.maxPaintedBlocks").getInt();
             consumeWaterSources = mainConfigManager.get("general.pumpsConsumeWater").getBoolean();
             miningMultiplier = (float) mainConfigManager.get("power.miningUsageMultiplier").getDouble();
             miningAllowPlayerProtectedBlocks = mainConfigManager.get("general.miningBreaksPlayerProtectedBlocks")

--- a/src/main/java/buildcraft/core/ItemPaintbrush.java
+++ b/src/main/java/buildcraft/core/ItemPaintbrush.java
@@ -21,6 +21,7 @@ import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import buildcraft.BuildCraftCore;
 import buildcraft.api.blocks.IColorRemovable;
 import buildcraft.api.core.EnumColor;
 import buildcraft.core.lib.items.ItemBuildCraft;
@@ -98,6 +99,7 @@ public class ItemPaintbrush extends ItemBuildCraft {
     public boolean onItemUseFirst(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side,
             float hitX, float hitY, float hitZ) {
         int dye = getColor(stack);
+
         Block block = world.getBlock(x, y, z);
 
         if (block == null) {
@@ -105,7 +107,8 @@ public class ItemPaintbrush extends ItemBuildCraft {
         }
 
         if (dye >= 0) {
-
+            int painted = 0;
+            int maxPainted = BuildCraftCore.maxPaintedBlocks;
             // Direction player is looking at
             ForgeDirection lookSide;
             Vec3 look = player.getLookVec();
@@ -125,6 +128,10 @@ public class ItemPaintbrush extends ItemBuildCraft {
                 player.swingItem();
                 setDamage(stack, getDamage(stack) + 1);
                 dye = getColor(stack);
+
+                painted++;
+                if (painted >= maxPainted && maxPainted != -1) return !world.isRemote;
+
                 if (!player.isSneaking() || dye <= 0) return !world.isRemote;
                 switch (lookSide) {
                     case UP:

--- a/src/main/java/buildcraft/core/ItemPaintbrush.java
+++ b/src/main/java/buildcraft/core/ItemPaintbrush.java
@@ -151,6 +151,9 @@ public class ItemPaintbrush extends ItemBuildCraft {
                     return !world.isRemote;
                 }
                 block = world.getBlock(x, y, z);
+                if( block == null){
+                    return !world.isRemote;
+                }
             }
 
         } else {

--- a/src/main/java/buildcraft/core/ItemPaintbrush.java
+++ b/src/main/java/buildcraft/core/ItemPaintbrush.java
@@ -151,7 +151,7 @@ public class ItemPaintbrush extends ItemBuildCraft {
                     return !world.isRemote;
                 }
                 block = world.getBlock(x, y, z);
-                if( block == null){
+                if (block == null) {
                     return !world.isRemote;
                 }
             }


### PR DESCRIPTION
When Player holds shift paintbrush will color all blocks in direction player is looking until it run out of color or block is not colourable