### PR TITLE
Populate gates creative tab

### DIFF
--- a/src/main/java/buildcraft/BuildCraftTransport.java
+++ b/src/main/java/buildcraft/BuildCraftTransport.java
@@ -443,7 +443,7 @@ public class BuildCraftTransport extends BuildCraftMod {
             pipeGate = new ItemGate();
             pipeGate.setUnlocalizedName("pipeGate");
             if (Loader.isModLoaded("BuildCraft|Silicon") && BCRegistry.INSTANCE.isItemEnabled(pipeGate)) {
-                new BCCreativeTab("gates");
+                pipeGate.setCreativeTab(new BCCreativeTab("gates"));
             }
             BCRegistry.INSTANCE.registerItem(pipeGate, false);
 

--- a/src/main/java/buildcraft/transport/gates/ItemGate.java
+++ b/src/main/java/buildcraft/transport/gates/ItemGate.java
@@ -30,7 +30,6 @@ import buildcraft.api.gates.IGateExpansion;
 import buildcraft.api.transport.IPipe;
 import buildcraft.api.transport.pluggable.IPipePluggableItem;
 import buildcraft.api.transport.pluggable.PipePluggable;
-import buildcraft.core.BCCreativeTab;
 import buildcraft.core.lib.inventory.InvUtils;
 import buildcraft.core.lib.items.ItemBuildCraft;
 import buildcraft.core.lib.utils.StringUtils;
@@ -53,7 +52,6 @@ public class ItemGate extends ItemBuildCraft implements IPipePluggableItem {
         setHasSubtypes(false);
         setMaxDamage(0);
         setPassSneakClick(true);
-        setCreativeTab(BCCreativeTab.getIfPresent("gates"));
     }
 
     private static NBTTagCompound getNBT(ItemStack stack) {


### PR DESCRIPTION
Fixes a circular dependency between `new ItemGate()` and `new BCCreativeTab("gates")` which causes the gates creative tab to be empty.