### PR TITLE
[Memory-opti:fix leak] Fix WorldServer leak

### DIFF
--- a/src/main/java/buildcraft/BuildCraftRobotics.java
+++ b/src/main/java/buildcraft/BuildCraftRobotics.java
@@ -144,7 +144,7 @@ import cpw.mods.fml.common.event.FMLInterModComms;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartedEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
-import cpw.mods.fml.common.event.FMLServerStoppingEvent;
+import cpw.mods.fml.common.event.FMLServerStoppedEvent;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.EntityRegistry;
@@ -609,7 +609,7 @@ public class BuildCraftRobotics extends BuildCraftMod {
     }
 
     @Mod.EventHandler
-    public void serverUnload(FMLServerStoppingEvent event) {
+    public void onServerStopped(FMLServerStoppedEvent event) {
         stopMapManager();
     }
 

--- a/src/main/java/buildcraft/robotics/map/MapManager.java
+++ b/src/main/java/buildcraft/robotics/map/MapManager.java
@@ -35,6 +35,9 @@ public class MapManager implements Runnable {
     public void stop() {
         stop = true;
         saveAllWorlds();
+        synchronized (worldMap) {
+            worldMap.clear();
+        }
     }
 
     public MapWorld getWorld(World world) {
@@ -159,7 +162,7 @@ public class MapManager implements Runnable {
             IChunkProvider provider = ws.getChunkProvider();
             if (provider instanceof ChunkProviderServer) {
                 for (Object o : ((ChunkProviderServer) provider).func_152380_a()) {
-                    if (o != null && o instanceof Chunk) {
+                    if (o instanceof Chunk) {
                         Chunk c = (Chunk) o;
                         if (!mw.hasChunk(c.xPosition, c.zPosition)) {
                             mw.updateChunkDelayed(c, (byte) (40 + Utils.RANDOM.nextInt(20)));


### PR DESCRIPTION
Turns out when you unregister a forge event class instance, that class instance is still referenced in forge's event system thus not getting garbage collected

So I manually clear the World map data when unregistering the event to avoid leaking the World object.

On top of that the mod used the `FMLServerStoppingEvent` to clear the data which fires too early, before the `WorldEvent.Unload` event fires on the server side. So by using the `FMLServerStoppedEvent` instead the event handler can now run properly and clear the world map.

![image](https://github.com/user-attachments/assets/a70e33fe-65d1-458b-bd58-fab47f58a565)