### PR TITLE
[Memory-opti:static allocations] Fix 2 memory issues

### DIFF
--- a/src/main/java/buildcraft/BuildCraftTransport.java
+++ b/src/main/java/buildcraft/BuildCraftTransport.java
@@ -11,7 +11,7 @@ import static buildcraft.core.lib.network.ChannelHandler.CLIENT_ONLY;
 import static buildcraft.core.lib.network.ChannelHandler.SERVER_ONLY;
 
 import java.io.PrintWriter;
-import java.util.LinkedList;
+import java.util.ArrayList;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
@@ -284,7 +284,7 @@ public class BuildCraftTransport extends BuildCraftMod {
 
     public static PipeExtensionListener pipeExtensionListener;
 
-    private static LinkedList<PipeRecipe> pipeRecipes = new LinkedList<PipeRecipe>();
+    private static ArrayList<PipeRecipe> pipeRecipes = new ArrayList<>(500);
     private static ChannelHandler transportChannelHandler;
 
     public IIconProvider pipeIconProvider = new PipeIconProvider();
@@ -603,6 +603,7 @@ public class BuildCraftTransport extends BuildCraftMod {
 
         if (BuildCraftCore.loadDefaultRecipes) {
             loadRecipes();
+            pipeRecipes = null;
         }
 
         TransportProxy.proxy.registerRenderers();
@@ -868,7 +869,7 @@ public class BuildCraftTransport extends BuildCraftMod {
                 recipe.result = new ItemStack(res, 8, i);
                 recipe.input = new Object[] { "ABC", 'A', ingredients[0], 'B', glass, 'C', ingredients[2] };
 
-                pipeRecipes.add(recipe);
+                if (pipeRecipes != null) pipeRecipes.add(recipe);
             }
         } else if (ingredients.length == 2) {
             for (int i = 0; i < 17; i++) {
@@ -885,14 +886,14 @@ public class BuildCraftTransport extends BuildCraftMod {
                 recipe.result = new ItemStack(res, 1, i);
                 recipe.input = new Object[] { left, right };
 
-                pipeRecipes.add(recipe);
+                if (pipeRecipes != null) pipeRecipes.add(recipe);
 
                 if (ingredients[1] instanceof ItemPipe && clas != PipeStructureCobblestone.class) {
                     PipeRecipe uncraft = new PipeRecipe();
                     uncraft.isShapeless = true;
                     uncraft.input = new Object[] { recipe.result };
                     uncraft.result = (ItemStack) right;
-                    pipeRecipes.add(uncraft);
+                    if (pipeRecipes != null) pipeRecipes.add(uncraft);
                 }
             }
         }

--- a/src/main/java/buildcraft/core/blueprints/SchematicRegistry.java
+++ b/src/main/java/buildcraft/core/blueprints/SchematicRegistry.java
@@ -26,19 +26,20 @@ import buildcraft.api.core.JavaTools;
 public final class SchematicRegistry implements ISchematicRegistry {
 
     public static SchematicRegistry INSTANCE = new SchematicRegistry();
-    private static final HashMap<Class<? extends Schematic>, Constructor<?>> emptyConstructorMap = new HashMap<Class<? extends Schematic>, Constructor<?>>();
+    private static final HashMap<Class<? extends Schematic>, Constructor<?>> emptyConstructorMap = new HashMap<>();
 
-    public final HashMap<String, SchematicConstructor> schematicBlocks = new HashMap<String, SchematicConstructor>();
+    public final HashMap<String, SchematicConstructor> schematicBlocks = new HashMap<>();
 
-    public final HashMap<Class<? extends Entity>, SchematicConstructor> schematicEntities = new HashMap<Class<? extends Entity>, SchematicConstructor>();
+    public final HashMap<Class<? extends Entity>, SchematicConstructor> schematicEntities = new HashMap<>();
 
-    private final HashSet<String> modsForbidden = new HashSet<String>();
-    private final HashSet<String> blocksForbidden = new HashSet<String>();
+    private final HashSet<String> modsForbidden = new HashSet<>();
+    private final HashSet<String> blocksForbidden = new HashSet<>();
 
     private SchematicRegistry() {}
 
-    public class SchematicConstructor {
+    public static class SchematicConstructor {
 
+        private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
         public final Class<? extends Schematic> clazz;
         public final Object[] params;
 
@@ -46,7 +47,7 @@ public final class SchematicRegistry implements ISchematicRegistry {
 
         SchematicConstructor(Class<? extends Schematic> clazz, Object[] params) throws IllegalArgumentException {
             this.clazz = clazz;
-            this.params = params;
+            this.params = params != null && params.length == 0 ? EMPTY_OBJECT_ARRAY : params;
             this.constructor = findConstructor();
         }
 


### PR DESCRIPTION
1. clear a temporary LinkedList that shows up as longest path from GC roots
2. use the same `Object[0]` instance instead of allocating  60 000 ones
![image](https://github.com/user-attachments/assets/cb838639-15dd-4776-8b9f-d993717f4605)
![image](https://github.com/user-attachments/assets/95cdec59-e574-42f5-a47f-d731d04bfcd6)