### PR TITLE
Fewer Allocations

### DIFF
--- a/src/main/java/buildcraft/BuildCraftCore.java
+++ b/src/main/java/buildcraft/BuildCraftCore.java
@@ -765,6 +765,7 @@ public class BuildCraftCore extends BuildCraftMod {
     public void textureHook(TextureStitchEvent.Post event) {
         FluidRenderer.onTextureReload();
         RenderLaser.onTextureReload();
+        TileEngineBase.onTextureReload();
     }
 
     public void reloadConfig(ConfigManager.RestartRequirement restartType) {

--- a/src/main/java/buildcraft/core/BlockEngine.java
+++ b/src/main/java/buildcraft/core/BlockEngine.java
@@ -30,7 +30,7 @@ public class BlockEngine extends BlockEngineBase {
     public String getTexturePrefix(int meta, boolean addPrefix) {
         if (texturePaths[meta] != null) {
             if (addPrefix) {
-                return texturePaths[meta].replaceAll(":", ":textures/blocks/");
+                return texturePaths[meta].replace(":", ":textures/blocks/");
             } else {
                 return texturePaths[meta];
             }

--- a/src/main/java/buildcraft/core/lib/engines/TileEngineBase.java
+++ b/src/main/java/buildcraft/core/lib/engines/TileEngineBase.java
@@ -45,6 +45,11 @@ public abstract class TileEngineBase extends TileBuildCraft
     public static final ResourceLocation TRUNK_OVERHEAT_TEXTURE = new ResourceLocation(
             "buildcraftcore:textures/blocks/engine/trunk_overheat.png");
 
+    private ResourceLocation cachedBaseTexture;
+    private ResourceLocation cachedChamberTexture;
+    private ResourceLocation cachedTrunkTexture; // null means use stage-based defaults
+    private boolean texturesCached;
+
     public enum EnergyStage {
 
         BLUE,
@@ -96,29 +101,46 @@ public abstract class TileEngineBase extends TileBuildCraft
         return ((BlockEngineBase) blockType).getTexturePrefix(getBlockMetadata(), true);
     }
 
+    private void cacheTextures() {
+        if (texturesCached) return;
+        texturesCached = true;
+
+        String prefix = getTexturePrefix();
+        if (prefix == null) return;
+
+        cachedBaseTexture = new ResourceLocation(prefix + "/base.png");
+        cachedChamberTexture = new ResourceLocation(prefix + "/chamber.png");
+        if (ResourceUtils.resourceExists(prefix + "/trunk.png")) {
+            cachedTrunkTexture = new ResourceLocation(prefix + "/trunk.png");
+        }
+    }
+
     public ResourceLocation getBaseTexture() {
-        if (getTexturePrefix() != null) {
-            return new ResourceLocation(getTexturePrefix() + "/base.png");
+        cacheTextures();
+        if (cachedBaseTexture != null) {
+            return cachedBaseTexture;
         } else {
             return new ResourceLocation("missingno");
         }
     }
 
     public ResourceLocation getChamberTexture() {
-        if (getTexturePrefix() != null) {
-            return new ResourceLocation(getTexturePrefix() + "/chamber.png");
+        cacheTextures();
+        if (cachedChamberTexture != null) {
+            return cachedChamberTexture;
         } else {
             return new ResourceLocation("missingno");
         }
     }
 
     public ResourceLocation getTrunkTexture(EnergyStage stage) {
-        if (getTexturePrefix() == null) {
+        cacheTextures();
+        if (cachedBaseTexture == null) {
             return TRUNK_OVERHEAT_TEXTURE;
         }
 
-        if (ResourceUtils.resourceExists(getTexturePrefix() + "/trunk.png")) {
-            return new ResourceLocation(getTexturePrefix() + "/trunk.png");
+        if (cachedTrunkTexture != null) {
+            return cachedTrunkTexture;
         }
 
         switch (stage) {

--- a/src/main/java/buildcraft/core/lib/engines/TileEngineBase.java
+++ b/src/main/java/buildcraft/core/lib/engines/TileEngineBase.java
@@ -45,10 +45,17 @@ public abstract class TileEngineBase extends TileBuildCraft
     public static final ResourceLocation TRUNK_OVERHEAT_TEXTURE = new ResourceLocation(
             "buildcraftcore:textures/blocks/engine/trunk_overheat.png");
 
+    private static int textureCacheVersion = 0;
+
     private ResourceLocation cachedBaseTexture;
     private ResourceLocation cachedChamberTexture;
     private ResourceLocation cachedTrunkTexture; // null means use stage-based defaults
     private boolean texturesCached;
+    private int cachedAtVersion = -1;
+
+    public static void onTextureReload() {
+        textureCacheVersion++;
+    }
 
     public enum EnergyStage {
 
@@ -102,43 +109,39 @@ public abstract class TileEngineBase extends TileBuildCraft
     }
 
     private void cacheTextures() {
-        if (texturesCached) return;
+        if (texturesCached && cachedAtVersion == textureCacheVersion) return;
         texturesCached = true;
+        cachedAtVersion = textureCacheVersion;
 
         String prefix = getTexturePrefix();
-        if (prefix == null) return;
+        if (prefix == null) {
+            cachedBaseTexture = new ResourceLocation("missingno");
+            cachedChamberTexture = new ResourceLocation("missingno");
+            cachedTrunkTexture = TRUNK_OVERHEAT_TEXTURE;
+            return;
+        }
 
         cachedBaseTexture = new ResourceLocation(prefix + "/base.png");
         cachedChamberTexture = new ResourceLocation(prefix + "/chamber.png");
         if (ResourceUtils.resourceExists(prefix + "/trunk.png")) {
             cachedTrunkTexture = new ResourceLocation(prefix + "/trunk.png");
+        } else {
+            cachedTrunkTexture = null;
         }
     }
 
     public ResourceLocation getBaseTexture() {
         cacheTextures();
-        if (cachedBaseTexture != null) {
-            return cachedBaseTexture;
-        } else {
-            return new ResourceLocation("missingno");
-        }
+        return cachedBaseTexture;
     }
 
     public ResourceLocation getChamberTexture() {
         cacheTextures();
-        if (cachedChamberTexture != null) {
-            return cachedChamberTexture;
-        } else {
-            return new ResourceLocation("missingno");
-        }
+        return cachedChamberTexture;
     }
 
     public ResourceLocation getTrunkTexture(EnergyStage stage) {
         cacheTextures();
-        if (cachedBaseTexture == null) {
-            return TRUNK_OVERHEAT_TEXTURE;
-        }
-
         if (cachedTrunkTexture != null) {
             return cachedTrunkTexture;
         }


### PR DESCRIPTION
1. Stops using .replaceAll() which compiles a regex pattern each time apparently
2. Caches a resource locations that shouldn't change

Stops this nonsense:
<img width="1215" height="309" alt="image" src="https://github.com/user-attachments/assets/a3e58f86-1c06-47dd-8d1d-68e10bf6c6f4" />

<img width="1203" height="266" alt="image" src="https://github.com/user-attachments/assets/447f45f1-2e39-4575-8a72-5fb439cb284f" />
